### PR TITLE
added trim to imagemagick

### DIFF
--- a/mathmode.js
+++ b/mathmode.js
@@ -46,6 +46,7 @@ module.exports = function(expr, options) {
   
   var convert_path = options.imagemagick_path || "convert";
   var convert = spawn(convert_path, [
+    "-trim",
     "-density", "" + size,
     "-quality", "100",
     "pdf:-",


### PR DESCRIPTION
The images created by mathmode are slightly larger than necessary. If this is not the intended behavior, it can be fixed by adding a trim flag in the imagemagick settings
